### PR TITLE
GS2Inventoryにコマ一覧を追加＋GUIで見れるように

### DIFF
--- a/GS2_deploy/PieceInventory.yaml
+++ b/GS2_deploy/PieceInventory.yaml
@@ -1,0 +1,134 @@
+GS2TemplateFormatVersion: "2019-05-01"
+
+Resources:
+  InventoryNamespace:
+    Type: GS2::Inventory::Namespace
+    Properties:
+      Name: PieceList
+
+  InventorySettings:
+    Type: GS2::Inventory::CurrentItemModelMaster
+    Properties:
+      NamespaceName: PieceList
+      Settings:
+        version: "2019-02-05"
+        inventoryModels:
+          - name: Piece
+            initialCapacity: 50
+            maxCapacity: 100
+            protectReferencedItem: false
+            itemModels:
+              - name: Osho
+                metadata:
+                  Name: 王将
+                  F: 1
+                  B: 1
+                  R: 1
+                  L: 1
+                  UL: 1
+                  LL: 1
+                  UR: 1
+                  LR: 1                  
+                stackingLimit: 1
+                allowMultipleStacks: true
+                sortValue: 1
+              - name: Hisha
+                metadata:
+                  Name: 飛車
+                  F: 5
+                  B: 5
+                  R: 5
+                  L: 5
+                  UL: 0
+                  LL: 0
+                  UR: 0
+                  LR: 0                  
+                stackingLimit: 1
+                allowMultipleStacks: true
+                sortValue: 2
+              - name: Kaku
+                metadata:
+                  Name: 角行
+                  F: 0
+                  B: 0
+                  R: 0
+                  L: 0
+                  UL: 5
+                  LL: 5
+                  UR: 5
+                  LR: 5                  
+                stackingLimit: 1
+                allowMultipleStacks: true
+                sortValue: 3
+              - name: Kin
+                metadata:
+                  Name: 金将
+                  F: 1
+                  B: 1
+                  R: 1
+                  L: 1
+                  UL: 1
+                  LL: 1
+                  UR: 0
+                  LR: 0                  
+                stackingLimit: 1
+                allowMultipleStacks: true
+                sortValue: 4
+              - name: Gin
+                metadata:
+                  Name: 銀将
+                  F: 1
+                  B: 0
+                  R: 0
+                  L: 0
+                  UL: 1
+                  LL: 1
+                  UR: 1
+                  LR: 1                  
+                stackingLimit: 1
+                allowMultipleStacks: true
+                sortValue: 5
+              - name: Keima
+                metadata:
+                  Name: 桂馬
+                  F: 0
+                  B: 0
+                  R: 0
+                  L: 0
+                  UL: 2
+                  LL: 0
+                  UR: 2
+                  LR: 0                  
+                stackingLimit: 1
+                allowMultipleStacks: true
+                sortValue: 6
+              - name: Kyousya
+                metadata:
+                  Name: 香車
+                  F: 5
+                  B: 0
+                  R: 0
+                  L: 0
+                  UL: 0
+                  LL: 0
+                  UR: 0
+                  LR: 0                  
+                stackingLimit: 1
+                allowMultipleStacks: true
+                sortValue: 7
+              - name: Hohei
+                metadata:
+                  Name: 歩
+                  F: 1
+                  B: 0
+                  R: 0
+                  L: 0
+                  UL: 0
+                  LL: 0
+                  UR: 0
+                  LR: 0                  
+                stackingLimit: 1
+                allowMultipleStacks: true
+                sortValue: 8
+    DependsOn:
+      - InventoryNamespace

--- a/GS2_deploy/initialize_account_template.yaml
+++ b/GS2_deploy/initialize_account_template.yaml
@@ -1,0 +1,31 @@
+GS2TemplateFormatVersion: "2019-05-01"
+Description: GS2-Account initialize template Version 2010-06-26
+
+Globals:
+  Alias:
+    AccountNamespaceName: game-0001
+    KeyNamespaceAccountAuthentication: account-encryption-key-namespace
+    KeyAccountAuthentication: account-encryption-key
+
+Resources:
+  KeyNamespaceAccountAuthentication:
+    Type: GS2::Key::Namespace
+    Properties:
+      Name: ${KeyNamespaceAccountAuthentication}
+
+  KeyAccountAuthentication:
+    Type: GS2::Key::Key
+    Properties:
+      NamespaceName: ${KeyNamespaceAccountAuthentication}
+      Name: ${KeyAccountAuthentication}
+    DependsOn:
+      - KeyNamespaceAccountAuthentication
+
+  AccountNamespace:
+    Type: GS2::Account::Namespace
+    Properties:
+      Name: ${AccountNamespaceName}
+
+Outputs:
+  AccountNamespaceName: !GetAttr AccountNamespace.Item.Name
+  KeyAccountAuthenticationKeyId: !GetAttr KeyAccountAuthentication.Item.KeyId

--- a/GS2_deploy/initialize_credential_template.yaml
+++ b/GS2_deploy/initialize_credential_template.yaml
@@ -1,0 +1,31 @@
+GS2TemplateFormatVersion: "2019-05-01"
+Description: GS2 SDK identifier template Version 2019-07-10
+
+Globals:
+  Alias:
+    ApplicationUserName: InGame
+
+Resources:
+  IdentifierApplicationUser:
+    Type: GS2::Identifier::User
+    Properties:
+      Name: ${ApplicationUserName}
+
+  IdentifierApplicationUserAttachPolicy:
+    Type: GS2::Identifier::AttachSecurityPolicy
+    Properties:
+      UserName: ${ApplicationUserName}
+      SecurityPolicyId: grn:gs2::system:identifier:securityPolicy:ApplicationAccess
+    DependsOn:
+      - IdentifierApplicationUser
+
+  IdentifierApplicationIdentifier:
+    Type: GS2::Identifier::Identifier
+    Properties:
+      UserName: ${ApplicationUserName}
+    DependsOn:
+      - IdentifierApplicationUser
+
+Outputs:
+  ApplicationClientId: !GetAttr IdentifierApplicationIdentifier.Item.ClientId
+  ApplicationClientSecret: !GetAttr IdentifierApplicationIdentifier.ClientSecret

--- a/Game/Assets/Scenes/AccountScene.unity
+++ b/Game/Assets/Scenes/AccountScene.unity
@@ -296,6 +296,7 @@ GameObject:
   - component: {fileID: 598855616}
   - component: {fileID: 598855615}
   - component: {fileID: 598855617}
+  - component: {fileID: 598855618}
   m_Layer: 0
   m_Name: SceneManager
   m_TagString: Untagged
@@ -339,6 +340,18 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 2ad762c75aec9b249ae45728a58ace38, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &598855618
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 598855614}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 518306b490692a5478c329e520c1a3d9, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1 &680184579
@@ -660,6 +673,7 @@ RectTransform:
   - {fileID: 1804947772}
   - {fileID: 1288540659}
   - {fileID: 1607647618}
+  - {fileID: 1558705347}
   m_Father: {fileID: 0}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -742,6 +756,85 @@ CanvasRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1473735955}
+  m_CullTransparentMesh: 1
+--- !u!1 &1558705346
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1558705347}
+  - component: {fileID: 1558705349}
+  - component: {fileID: 1558705348}
+  m_Layer: 5
+  m_Name: Item
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1558705347
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1558705346}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1361183126}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -8, y: 40.376}
+  m_SizeDelta: {x: 329.1705, y: 80.7511}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1558705348
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1558705346}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 14
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 10
+    m_MaxSize: 40
+    m_Alignment: 0
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: New Text
+--- !u!222 &1558705349
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1558705346}
   m_CullTransparentMesh: 1
 --- !u!1 &1607647617
 GameObject:

--- a/Game/Assets/Scripts/AccountScene.cs
+++ b/Game/Assets/Scripts/AccountScene.cs
@@ -7,15 +7,25 @@ using UnityEngine.UI;
 public class AccountScene : MonoBehaviour
 {
     private Text UserNameText;
+    private Text ItemList;
+    public static string InventoryItem;
     // Start is called before the first frame update
     void Start()
     {
         UserNameText = GameObject.Find("UsernameMsg").gameObject.GetComponent<Text>();
+        ItemList = GameObject.Find("Item").gameObject.GetComponent<Text>();
     }
 
     // Update is called once per frame
     void Update()
     {
         UserNameText.text = "ユーザー名： " + AccountPrefs.GetAccountUsername();
+        string msg = AccountManager.PieceList[0].Name;
+        for (int i = 1; i < AccountManager.PieceList.Count; i++)
+        {
+            msg = msg + " " + AccountManager.PieceList[i].Name;
+        }
+        ItemList.text = msg;
+
     }
 }

--- a/Game/Assets/Scripts/Login/GS2Manager/AccountInfo.cs
+++ b/Game/Assets/Scripts/Login/GS2Manager/AccountInfo.cs
@@ -6,14 +6,14 @@ public class AccountInfo : MonoBehaviour
 {
     
     // クレデンシャルの定義情報
-    private readonly static string applicationClientId = "GKI-HJRpsKueh64OQPohmRCew4f-Ic7fp43_ZlPdjnUDg2W5WXRe523vJ6oD-xNv3j8";
-    private readonly static string applicationClientSecret = "NGZWSmJJMU5TMVFxMnlwUzdnd0NnQ0RtSjltaDVXeHk=";
+    private readonly static string applicationClientId = "GKIBT3C-iAYWbW7CuI8nCh0QhxPH0gjHlJcAtI2t1TACE7cPFBWuCYXgLKamIHW4gM-";
+    private readonly static string applicationClientSecret = "RmJkQnY3TWI2S3pabEg0clVwOTMyem5LeUN0UmRGQmE=";
 
 
     // アカウントの定義情報
     private readonly static string accountNameSpaceName = "game-0001";
-    private readonly static string keyAccountAuthenticationKeyId = "grn:gs2:ap-northeast-1:iy1YogLz-tryal:key:account-encryption-key-namespace:key:account-encryption-key";
- 
+    private readonly static string keyAccountAuthenticationKeyId = "grn:gs2:ap-northeast-1:iy1YogLz-StrategyGame:key:account-encryption-key-namespace:key:account-encryption-key";
+
 
     // ClientIdの取得処理
     public static string GetApplicationClientId()

--- a/Game/Assets/Scripts/Login/GS2Manager/AccountManager.cs
+++ b/Game/Assets/Scripts/Login/GS2Manager/AccountManager.cs
@@ -3,9 +3,14 @@ using System.Collections;
 using System.Collections.Generic;
 
 using Gs2.Core;
+//using Gs2.Core.AsyncResult;
 using Gs2.Unity.Gs2Account.Model;
 using Gs2.Unity.Gs2Account.Result;
+using Gs2.Unity.Gs2Inventory.Model;
+using Gs2.Unity.Gs2Inventory.Result;
 using Gs2.Unity.Util;
+
+using UnityEngine.UI;
 
 using UnityEngine;
 
@@ -15,11 +20,14 @@ public class AccountManager : MonoBehaviour
 	private static Gs2.Unity.Client gs2;                    // GS2 Client情報
 	private static EzAccount account = null;                // GS2 アカウント情報
 	private static GameSession session = null;              // GS2 セッション情報
+	public static List<EzItemModel> PieceList;
 
 	public const int ACCOUNTSTATE_INIT = 0;     // 未ログイン状態
 	public const int ACCOUNTSTATE_NOW = 1;      // ログイン処理中	
 	public const int ACCOUNTSTATE_FAILED = 2;       // ログイン失敗
 	public const int ACCOUNTSTATE_SUCCESS = 3;  // ログイン成功
+
+	//public static string InventoryItem = "none";
 
 	private static int accountState = ACCOUNTSTATE_INIT;    // アカウント状態
 
@@ -139,6 +147,26 @@ public class AccountManager : MonoBehaviour
 
 		// 状態更新(ログイン成功)
 		accountState = ACCOUNTSTATE_SUCCESS;
+		//コマの情報を取得
+
+		AsyncResult<EzListItemModelsResult> asyncResult = null;
+
+		var PieceCurrent = gs2.Inventory.ListItemModels(
+			callback: r =>
+			{
+				asyncResult = r;
+			},
+			namespaceName: "PieceList",
+			inventoryName: "Piece"
+		);
+		yield return PieceCurrent;
+		if (asyncResult.Error != null)
+		{
+			yield break;
+		}
+
+		var PieceResult = asyncResult.Result;
+		PieceList = PieceResult.Items;
 	}
 
 	// ログイン処理
@@ -222,6 +250,28 @@ public class AccountManager : MonoBehaviour
 
 		// 状態更新(ログイン成功)
 		accountState = ACCOUNTSTATE_SUCCESS;
+
+		//コマの情報を取得
+
+		AsyncResult<EzListItemModelsResult> asyncResult = null;
+
+		var PieceCurrent = gs2.Inventory.ListItemModels(
+			callback: r =>
+			{
+				asyncResult = r;
+			},
+			namespaceName: "PieceList",
+			inventoryName: "Piece"
+		);
+		yield return PieceCurrent;
+		if (asyncResult.Error != null)
+		{
+			yield break;
+		}
+
+		var PieceResult = asyncResult.Result;
+		PieceList = PieceResult.Items;
+
 	}
 
 	//ログアウト処理
@@ -250,4 +300,6 @@ public class AccountManager : MonoBehaviour
 	{
 		return accountState;
 	}
+
+	
 }


### PR DESCRIPTION
close #22 
- GS2Inventoryにコマデータ（とりあえず将棋の駒の名前で）を保存
- コマのメタデータ
  - 表示名
  - 8方にどれだけ進めるか
  
- UnityのAccount画面で名前一覧を表示できるように

今後は、メタデータを分割してコマのデータを取得したいよね